### PR TITLE
Update 1_tiled_gridded_elevation_data.adoc

### DIFF
--- a/spec/1_tiled_gridded_elevation_data.adoc
+++ b/spec/1_tiled_gridded_elevation_data.adoc
@@ -127,7 +127,32 @@ The following requirements refer to the `gpkg_2D_gridded_tile_ancillary` table a
 
 === Table Definition SQL
 
-TBD
+.Coverage Ancillary Table
+
+ CREATE TABLE `gpkg_2D_gridded_coverage_ancillary` (
+ 	`id`	INTEGER PRIMARY KEY AUTOINCREMENT,
+ 	`tile_matrix_set`	TEXT NOT NULL,
+ 	`datatype`	TEXT NOT NULL DEFAULT 'integer',
+ 	`uom`	TEXT NOT NULL,
+ 	`scale`	REAL DEFAULT 1.0,
+ 	`offset`	REAL DEFAULT 0.0,
+ 	`precision`	REAL DEFAULT 1.0,
+ 	FOREIGN KEY(`tile_matrix_set`) REFERENCES gpkg_tile_matrix_set ( table_name )
+ 	CHECK (`datatype` in ('integer','float'))
+ );
+
+.Tile Ancillary Table
+
+ CREATE TABLE `gpkg_2D_gridded_tile_ancillary` (
+ 	`id`	INTEGER PRIMARY KEY AUTOINCREMENT,
+ 	`tpudt_name`	TEXT NOT NULL,
+ 	`tpudt_id`	INTEGER NOT NULL,
+ 	`min`	REAL DEFAULT NULL,
+ 	`max`	REAL DEFAULT NULL,
+ 	`mean`	REAL DEFAULT NULL,
+ 	`std_dev`	REAL DEFAULT NULL,
+ 	FOREIGN KEY(`tpudt_name`) REFERENCES gpkg_contents ( table_name )
+ );
 
 === References
 


### PR DESCRIPTION
Add SQL CREATE TABLE statements.

fixes opengeospatial/geopackage#127
1. The gpkg_2D_gridded_coverage_ancillary.datatype value is limited to a value of `integer`. I don't recall our discussions of adding`float` or not as well. Should we allow floating point values?
2. Should we add a foreign key constraint on the `gpkg_2D_gridded_tile_ancillary .tpudt_name`? 
3. I feel we should we remove the foreign key constraint from the column definition on `gpkg_2D_gridded_tile_ancillary.tpudt_id`. This is a soft constraint, and cannot be enforced in the CREATE TABLE SQL (the user data table’s name is dynamic).
