### PR TITLE
Formatting on Table 1. Coverage Ancillary Table Definition

### DIFF
--- a/spec/2_tiled_gridded_elevation_data_tiff.adoc
+++ b/spec/2_tiled_gridded_elevation_data_tiff.adoc
@@ -75,11 +75,11 @@ Clients SHALL ignore additional columns that are unrecognized.
 [cols=",,,,,",options="header",]
 |=======================================================================
 |Column Name |Column Type |Column Description |Null |Default |Key|Constraint
-|`id`|INTEGER |Autoincrement primary key|no||PK
+|`id`|INTEGER |Autoincrement primary key|no||PK|
 |`tile_matrix_set_name`|TEXT|Foreign key to `table_name` in http://www.geopackage.org/spec/#tile_matrix_set_data_table_definition[`gpkg_tile_matrix_set`]|no||FK|UNIQUE
-|`datatype`|TEXT  |'float'|no||
-|`precision`|REAL{real_value}|The smallest value that has meaning for this dataset|yes|1|
-|`data_null`|REAL{real_value}|The value that indicates NULL|yes||
+|`datatype`|TEXT  |'float'|no|||
+|`precision`|REAL{real_value}|The smallest value that has meaning for this dataset|yes|1||
+|`data_null`|REAL{real_value}|The value that indicates NULL|yes|||
 |=======================================================================
 
 


### PR DESCRIPTION
rows and columns are not lined up
