### PR TITLE
missing comma after fk_g2dgtct_name constraint & formatting

### DIFF
--- a/standard/annex-c.adoc
+++ b/standard/annex-c.adoc
@@ -7,35 +7,20 @@
 [source,sql]
 ----
 CREATE TABLE 'gpkg_2d_gridded_coverage_ancillary' (
-
-id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-
-tile_matrix_set_name TEXT NOT NULL UNIQUE,
-
-datatype TEXT NOT NULL DEFAULT 'integer',
-
-scale REAL NOT NULL DEFAULT 1.0,
-
-offset REAL NOT NULL DEFAULT 0.0,
-
-precision REAL DEFAULT 1.0,
-
-data_null REAL,
-
-grid_cell_encoding TEXT DEFAULT 'grid-value-is-center',
-
-uom TEXT,
-
-field_name TEXT DEFAULT 'Height',
-
-quantity_definition TEXT DEFAULT 'Height',
-
-CONSTRAINT fk_g2dgtct_name FOREIGN KEY('tile_matrix_set_name') REFERENCES
-
-gpkg_tile_matrix_set ( table_name )
-
-CHECK (datatype in ('integer','float')));
-
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  tile_matrix_set_name TEXT NOT NULL UNIQUE,
+  datatype TEXT NOT NULL DEFAULT 'integer',
+  scale REAL NOT NULL DEFAULT 1.0,
+  offset REAL NOT NULL DEFAULT 0.0,
+  precision REAL DEFAULT 1.0,
+  data_null REAL,
+  grid_cell_encoding TEXT DEFAULT 'grid-value-is-center',
+  uom TEXT,
+  field_name TEXT DEFAULT 'Height',
+  quantity_definition TEXT DEFAULT 'Height',
+  CONSTRAINT fk_g2dgtct_name FOREIGN KEY('tile_matrix_set_name') REFERENCES gpkg_tile_matrix_set (table_name),
+  CHECK (datatype in ('integer','float'))
+);
 ----
 
 
@@ -44,27 +29,16 @@ CHECK (datatype in ('integer','float')));
 [source,sql]
 ----
 CREATE TABLE gpkg_2d_gridded_tile_ancillary (
-
-id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-
-tpudt_name TEXT NOT NULL,
-
-tpudt_id INTEGER NOT NULL,
-
-scale REAL NOT NULL DEFAULT 1.0,
-
-offset REAL NOT NULL DEFAULT 0.0,
-
-min REAL DEFAULT NULL,
-
-max REAL DEFAULT NULL,
-
-mean REAL DEFAULT NULL,
-
-std_dev REAL DEFAULT NULL,
-
-CONSTRAINT fk_g2dgtat_name FOREIGN KEY (tpudt_name) REFERENCES gpkg_contents(table_name),
-
-UNIQUE (tpudt_name, tpudt_id));
-
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  tpudt_name TEXT NOT NULL,
+  tpudt_id INTEGER NOT NULL,
+  scale REAL NOT NULL DEFAULT 1.0,
+  offset REAL NOT NULL DEFAULT 0.0,
+  min REAL DEFAULT NULL,
+  max REAL DEFAULT NULL,
+  mean REAL DEFAULT NULL,
+  std_dev REAL DEFAULT NULL,
+  CONSTRAINT fk_g2dgtat_name FOREIGN KEY (tpudt_name) REFERENCES gpkg_contents(table_name),
+  UNIQUE (tpudt_name, tpudt_id)
+);
 ----


### PR DESCRIPTION
The gpkg_2d_gridded_coverage_ancillary table is missing a comma after the fk_g2dgtct_name constraint and before the CHECK constraint.
https://www.sqlite.org/lang_createtable.html

Also updated the table formatting to match the GeoPackage spec table definitions.